### PR TITLE
build: добавить docker-compose для Postgres и приложения

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# Виртуальные окружения
+.venv/
+venv/
+ENV/
+env/
+
+# IDE и редакторы
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Git
+.git
+.gitignore
+
+# Логи и временные файлы
+*.log
+*.tmp
+*.bak
+
+# Тесты (внутри контейнера не нужны)
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Локальная SQLite база (в контейнере мы юзаем Postgres)
+app.db
+
+# Медиа-файлы: они должны храниться во внешнем volume, а не в образе
+app/media/
+
+# Docker
+docker-compose.override.yml

--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+# Database (Postgres inside Docker)
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/twitter
+
+# Security
+SECRET_KEY=change-me
+ACCESS_TOKEN_EXPIRE_MINUTES=60

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 __pycache__/
 *.pyc
 .venv/
-.env
+.env.local
 app/media/
 app.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Базовый образ Python
+FROM python:3.12-slim
+
+# Рабочая директория внутри контейнера
+WORKDIR /code
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential && rm -rf /var/lib/apt/lists/*
+
+# Устанавливаем зависимости
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Копируем всё приложение внутрь контейнера
+COPY . .
+
+# Команда запуска (перезаписывается в docker-compose.yml)
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,21 @@
+# Базовый образ Python
+FROM python:3.12-slim
+
+# Рабочая директория внутри контейнера
+WORKDIR /code
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential && rm -rf /var/lib/apt/lists/*
+
+# Устанавливаем зависимости
+COPY requirements.txt .
+COPY requirements-dev.txt .
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir -r requirements-dev.txt
+
+# Копируем всё приложение внутрь контейнера
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["/bin/sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"]

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
 
     model_config = SettingsConfigDict(
-        env_file=".env",  # читать переменные из .env
+        env_file=".env.local",  # читать переменные из .env.local
         case_sensitive=True,  # имена переменных чувствительны к регистру
     )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16
+    container_name: twitter_db
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: twitter
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d twitter"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: twitter_app
+    restart: always
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+    ports:
+      - "8000:8000"
+    # для локальной разработки удобно:
+    command: /bin/sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
+    volumes:
+      - .:/code
+      - media_data:/code/app/media
+
+volumes:
+  postgres_data:
+  media_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pydantic
 pydantic-settings
 alembic
 aiosqlite
+asyncpg
+aiosqlite


### PR DESCRIPTION
Добавлен docker-compose.yml с сервисами:
db (Postgres 16, healthcheck, volume для данных),
app (FastAPI + uvicorn, автозапуск Alembic миграций)
Добавлен Dockerfile.dev (для разработки) и Dockerfile.prod.
Добавлен .dockerignore.
Обновлён .env.example для Postgres.
Настроен volume для app/media (файлы сохраняются на хосте).
Проверено: контейнеры поднимаются, миграции применяются, Swagger доступен по http://localhost:8000/docs.