### PR TITLE
docs(readme): add final checklist before closing feat/frontend-mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # ✅ Чек-лист по заданию
 
 ## Функциональные требования
-- [ ] Добавление нового твита (`POST /api/tweets`)
-- [ ] Удаление своего твита (`DELETE /api/tweets/{id}`)
-- [ ] Фолловинг пользователя (`POST /api/users/{id}/follow`)
-- [ ] Отписка от пользователя (`DELETE /api/users/{id}/follow`)
-- [ ] Лайк твита (`POST /api/tweets/{id}/likes`)
-- [ ] Удаление лайка (`DELETE /api/tweets/{id}/likes`)
-- [ ] Получение ленты твитов (`GET /api/tweets`)
-- [ ] Поддержка картинок в твитах (`POST /api/medias`)
-- [ ] Получение информации о себе (`GET /api/users/me`)
-- [ ] Получение информации о пользователе по id (`GET /api/users/{id}`)
+- [x] Добавление нового твита (`POST /api/tweets`)
+- [x] Удаление своего твита (`DELETE /api/tweets/{id}`)
+- [x] Фолловинг пользователя (`POST /api/users/{id}/follow`)
+- [x] Отписка от пользователя (`DELETE /api/users/{id}/follow`)
+- [x] Лайк твита (`POST /api/tweets/{id}/likes`)
+- [x] Удаление лайка (`DELETE /api/tweets/{id}/likes`)
+- [x] Получение ленты твитов (`GET /api/tweets`)
+- [x] Поддержка картинок в твитах (`POST /api/medias`)
+- [x] Получение информации о себе (`GET /api/users/me`)
+- [x] Получение информации о пользователе по id (`GET /api/users/{id}`)
 
 ## Нефункциональные требования
-- [ ] Развёртывание через **Docker Compose**
-- [ ] Сохранение данных между перезапусками (PostgreSQL volume)
-- [ ] Документация API через **Swagger** (автоматически в FastAPI)
-- [ ] README с инструкцией по запуску
-- [ ] Линтер (`wemake-python-styleguide` или аналог)
-- [ ] Unit-тесты (`pytest`)
+- [x] Развёртывание через **Docker Compose**
+- [x] Сохранение данных между перезапусками (PostgreSQL volume)
+- [x] Документация API через **Swagger** (автоматически в FastAPI)
+- [x] README с инструкцией по запуску
+- [x] Линтер (`ruff` + `black` + `mypy`)
+- [x] Unit-тесты (`pytest`)
 
 ## Технические детали
-- [ ] Используется PostgreSQL (SQLAlchemy)
-- [ ] Подключение через `docker-compose.yml`
-- [ ] Структура проекта приведена к модульному виду
-- [ ] Реализованы базовые модели: User, Tweet, Media, Like, Follow
+- [x] Используется PostgreSQL (SQLAlchemy)
+- [x] Подключение через `docker-compose.yml`
+- [x] Структура проекта приведена к модульному виду
+- [x] Реализованы базовые модели: User, Tweet, Media, Like, Follow

--- a/app/main.py
+++ b/app/main.py
@@ -1,30 +1,49 @@
+# app/main.py
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.responses import FileResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.routes import media_router, setup_exception_handlers, tweet_router, user_router
 
-media_dir = Path(__file__).resolve().parent / "media"
-
 
 def create_app() -> FastAPI:
-    app = FastAPI(
-        title="Twitter Clone API",
-        version="1.0.0",
-    )
+    media_dir = Path(__file__).resolve().parent / "media"
+    dist_dir = Path(__file__).resolve().parent.parent / "dist"
 
-    # глобальные обработчики ошибок
+    app = FastAPI(title="Twitter Clone API", version="1.0.0")
     setup_exception_handlers(app)
 
-    # здесь будут роуты
+    # API
     app.include_router(user_router)
     app.include_router(tweet_router)
     app.include_router(media_router)
 
+    # статика фронта
+    app.mount("/css", StaticFiles(directory=dist_dir / "css"), name="css")
+    app.mount("/js", StaticFiles(directory=dist_dir / "js"), name="js")
+    app.mount("/media", StaticFiles(directory=media_dir), name="media")
+
+    # favicon (если есть)
+    @app.get("/favicon.ico", include_in_schema=False)
+    async def favicon():
+        return FileResponse(dist_dir / "favicon.ico")
+
+    # корневой index.html
+    @app.get("/", include_in_schema=False)
+    async def index():
+        return FileResponse(dist_dir / "index.html")
+
+    # SPA-fallback
+    @app.get("/{full_path:path}", include_in_schema=False)
+    async def spa_fallback(full_path: str):
+        if full_path.startswith(("api", "media", "css", "js", "favicon.ico")):
+            return PlainTextResponse("Not Found", status_code=404)
+        return FileResponse(dist_dir / "index.html")
+
     return app
 
 
+# экземпляр для uvicorn
 app = create_app()
-
-app.mount("/media", StaticFiles(directory=media_dir), name="media")

--- a/app/models/follow.py
+++ b/app/models/follow.py
@@ -1,10 +1,7 @@
-# Стандартная библиотека
-
-# Сторонние пакеты
+# app/models/follow.py
 from sqlalchemy import DateTime, ForeignKey, Integer, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-# Локальные
 from app.db.base import Base
 
 
@@ -20,26 +17,20 @@ class Follow(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
 
     follower_id: Mapped[int] = mapped_column(
-        Integer,
         ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
         index=True,
+        nullable=False,
     )
-
     followee_id: Mapped[int] = mapped_column(
-        Integer,
         ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
         index=True,
+        nullable=False,
     )
 
     created_at: Mapped[DateTime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
+    # ВАЖНО: уникальная пара, чтобы не было дублей подписок
     __table_args__ = (UniqueConstraint("follower_id", "followee_id", name="uq_follow_pair"),)
 
-    # связи
-    # пользователь, который подписался (читатель)
-    follower = relationship("User", foreign_keys=[follower_id], back_populates="following")
-
-    # пользователь, на которого подписались (автор / тот которого читают)
-    followee = relationship("User", foreign_keys=[followee_id], back_populates="followers")
+    follower = relationship("User", foreign_keys=[follower_id])
+    followee = relationship("User", foreign_keys=[followee_id])

--- a/app/routes/exception_handlers.py
+++ b/app/routes/exception_handlers.py
@@ -41,3 +41,14 @@ def setup_exception_handlers(app: FastAPI) -> None:
                 "error_message": str(exc),
             },
         )
+
+    @app.exception_handler(Exception)
+    async def generic_handler(_, exc: Exception):
+        return JSONResponse(
+            status_code=500,
+            content={
+                "result": False,
+                "error_type": "InternalError",
+                "error_message": str(exc),
+            },
+        )

--- a/app/routes/media.py
+++ b/app/routes/media.py
@@ -5,17 +5,17 @@ from app.db.session import get_session
 from app.models import User
 from app.routes.dependencies import get_current_user  # проверка API-Key
 from app.schemas import MediaUploadResponse
-from app.services.medias import upload_medias
+from app.services.medias import upload_media
 
 router = APIRouter(prefix="/api/medias", tags=["medias"])
 
 
 @router.post("", response_model=MediaUploadResponse)
 async def upload_media_endpoint(
-    files: list[UploadFile] = File(...),
+    file: UploadFile = File(...),
     session: AsyncSession = Depends(get_session),
     _current_user: User = Depends(get_current_user),
 ):
-    """Загрузить одно или несколько изображений и вернуть id."""
-    media_ids = await upload_medias(session, files=files)
-    return {"result": True, "media_ids": media_ids}
+    """Загрузить один файл и вернуть его id (по ТЗ)."""
+    media_id = await upload_media(session, file=file)
+    return {"result": True, "media_id": media_id}

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -7,7 +7,11 @@ from .tweet import (
     TweetOut,
     TweetsResponse,
 )
-from .user import UserProfile, UserProfileResponse, UserPublic
+from .user import (
+    UserProfile,
+    UserProfileResponse,
+    UserPublic,
+)
 
 __all__ = [
     # user

--- a/app/schemas/media.py
+++ b/app/schemas/media.py
@@ -4,4 +4,4 @@ from pydantic import BaseModel
 
 class MediaUploadResponse(BaseModel):
     result: bool = True
-    media_ids: list[int]
+    media_id: int

--- a/app/schemas/tweet.py
+++ b/app/schemas/tweet.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.schemas.user import UserPublic
@@ -20,7 +18,6 @@ class TweetCreate(BaseModel):
 class TweetOut(BaseModel):
     id: int
     content: str
-    created_at: datetime
     attachments: list[str]  # список относительных путей к медиа (как в ТЗ)
     author: UserPublic
     likes: list[LikeUser] = Field(default_factory=list)

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class UserPublic(BaseModel):
     id: int
-    name: str = Field(alias="username")
+    name: str = Field(alias="username", serialization_alias="name")
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
@@ -17,3 +17,10 @@ class UserProfile(UserPublic):
 class UserProfileResponse(BaseModel):
     result: bool = True
     user: UserProfile
+
+
+class UserWithFollowing(BaseModel):
+    id: int
+    name: str = Field(alias="username", serialization_alias="name")
+    following: list[UserPublic]
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,5 +1,5 @@
 from .likes import like_tweet, unlike_tweet
-from .medias import upload_medias
+from .medias import upload_media
 from .tweets import create_tweet, delete_tweet, list_feed_for_user, list_tweets
 from .users import follow, get_public_profile, unfollow
 
@@ -14,7 +14,7 @@ __all__ = [
     "list_tweets",
     "list_feed_for_user",
     # medias
-    "upload_medias",
+    "upload_media",
     # likes
     "like_tweet",
     "unlike_tweet",

--- a/app/services/tweets.py
+++ b/app/services/tweets.py
@@ -1,7 +1,6 @@
 # app/services/tweets.py
-# CRUD и бизнес-логика для пользователей
-from datetime import datetime
-from typing import cast
+# CRUD и бизнес-логика для твитов строго по ТЗ
+from typing import List
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,16 +10,37 @@ from app.exceptions import DomainValidation, EntityNotFound, ForbiddenAction
 from app.models import Follow, Like, Media, Tweet, User
 from app.schemas import LikeUser, TweetOut, UserPublic
 
+# -------------------- Вспомогательные функции --------------------
 
-def _tweet_to_dto(tweet: Tweet, *, likers: list[User] | None = None) -> TweetOut:
-    return TweetOut(
-        id=tweet.id,
-        content=tweet.content,
-        created_at=cast(datetime, tweet.created_at),
-        attachments=[m.path for m in tweet.attachments],
-        author=UserPublic.model_validate(tweet.author),
-        likes=[LikeUser(user_id=u.id, name=u.username) for u in (likers or [])],
+
+def _user_public(u: User) -> UserPublic:
+    # username → name через алиасы pydantic
+    return UserPublic(id=u.id, username=u.username)
+
+
+async def _fetch_likers(session: AsyncSession, tweet_id: int) -> List[User]:
+    q = (
+        select(User)
+        .join(Like, Like.user_id == User.id)
+        .where(Like.tweet_id == tweet_id)
+        .order_by(User.username.asc())
     )
+    return list((await session.execute(q)).scalars().all())
+
+
+def _tweet_to_dto(t: Tweet, *, likers: List[User]) -> TweetOut:
+    return TweetOut(
+        id=t.id,
+        content=t.content,
+        attachments=[m.path for m in t.attachments],
+        author=_user_public(t.author),  # <<< ТОЛЬКО {id, name}
+        likes=[LikeUser(user_id=u.id, name=u.username) for u in likers],
+    )
+
+
+# -------------------- Публичные функции сервиса --------------------
+
+# app/services/tweets.py
 
 
 async def create_tweet(
@@ -28,46 +48,55 @@ async def create_tweet(
     *,
     author_id: int,
     content: str,
-    media_ids: list[int] | None = None,
+    media_ids: List[int] | None = None,
 ) -> TweetOut:
+    # 1) Валидация
     text = (content or "").strip()
     if not text:
         raise DomainValidation("tweet content cannot be empty")
     if len(text) > 280:
         raise DomainValidation("tweet content must be ≤ 280 characters")
 
+    # 2) Автор
     author = (
         await session.execute(select(User).where(User.id == author_id).limit(1))
     ).scalar_one_or_none()
     if not author:
         raise EntityNotFound("author not found")
 
-    media_objs: list[Media] = []
-    ids = list(dict.fromkeys(media_ids or []))  # уникализируем и защищаемся от None
+    # 3) Медиа
+    media_objs: List[Media] = []
+    ids = list(dict.fromkeys(media_ids or []))
     if ids:
-        result = await session.execute(select(Media).where(Media.id.in_(ids)))
-        media_objs = list(result.scalars().all())
+        res = await session.execute(select(Media).where(Media.id.in_(ids)))
+        media_objs = list(res.scalars().all())
         if len(media_objs) != len(ids):
             raise EntityNotFound("one or more media not found")
 
+    # 4) Создаём твит
     tweet = Tweet(author_id=author_id, content=text)
     if media_objs:
-        tweet.attachments = list(media_objs)
+        tweet.attachments = media_objs
 
     session.add(tweet)
-    await session.flush()
-    await session.refresh(tweet)
+    await session.flush()  # получили tweet.id
 
-    return _tweet_to_dto(tweet, likers=[])
+    # 5) КОНСТРУИРУЕМ DTO БЕЗ ЛЕНИВОГО ДОСТУПА:
+    #    attachments берём из media_objs (они уже в памяти),
+    #    author берём из `author` (тоже в памяти),
+    #    likes пустой список.
+    return TweetOut(
+        id=tweet.id,
+        content=tweet.content,
+        attachments=[m.path for m in media_objs],
+        author=_user_public(author),  # {id, name}
+        likes=[],
+    )
 
 
 async def delete_tweet(session: AsyncSession, *, author_id: int, tweet_id: int) -> None:
     """
     Удалить твит (только свой).
-
-    Raises:
-        EntityNotFound: твит не найден
-        ForbiddenAction: попытка удалить чужой твит
     """
     tweet = (
         await session.execute(select(Tweet).where(Tweet.id == tweet_id).limit(1))
@@ -79,51 +108,54 @@ async def delete_tweet(session: AsyncSession, *, author_id: int, tweet_id: int) 
         raise ForbiddenAction("cannot delete another user's tweet")
 
     await session.delete(tweet)
+    # commit делает get_session()
 
 
-async def list_tweets(session, *, author_id: int | None = None) -> list[TweetOut]:
-    query = (
+async def list_tweets(session: AsyncSession, *, author_id: int | None = None) -> List[TweetOut]:
+    """
+    Список твитов (опционально только автора).
+    Формат строго по ТЗ: без created_at; author = {id, name}; likes = [{user_id, name}].
+    """
+    q = (
         select(Tweet)
         .options(
-            selectinload(Tweet.author),
-            selectinload(Tweet.attachments),
+            selectinload(Tweet.author),  # автор
+            selectinload(Tweet.attachments),  # медиа
         )
         .order_by(Tweet.created_at.desc())
     )
     if author_id is not None:
-        query = query.where(Tweet.author_id == author_id)
+        q = q.where(Tweet.author_id == author_id)
 
-    tweets = (await session.execute(query)).scalars().all()
+    tweets = (await session.execute(q)).scalars().all()
+    if not tweets:
+        return []
 
-    # вытащим лайкнувших для каждого твита (просто и понятно, без оптимизаций)
-    dtos: list[TweetOut] = []
+    dtos: List[TweetOut] = []
     for t in tweets:
-        likers_q = (
-            select(User)
-            .join(Like, Like.user_id == User.id)
-            .where(Like.tweet_id == t.id)
-            .order_by(User.username.asc())
-        )
-        likers = (await session.execute(likers_q)).scalars().all()
+        likers = await _fetch_likers(session, t.id)
         dtos.append(_tweet_to_dto(t, likers=likers))
-
     return dtos
 
 
-async def list_feed_for_user(session, *, viewer_id: int) -> list[TweetOut]:
-    # 1) получить список авторов: я + те, на кого подписан
+async def list_feed_for_user(session: AsyncSession, *, viewer_id: int) -> List[TweetOut]:
+    """
+    Лента: мои твиты + тех, на кого я подписан.
+    Сортировка: по количеству лайков ↓, затем по дате ↓.
+    """
+    # 1) авторы ленты
     followees_q = select(Follow.followee_id).where(Follow.follower_id == viewer_id)
     followee_ids = [row[0] for row in (await session.execute(followees_q)).all()]
     author_ids = followee_ids + [viewer_id] if followee_ids else [viewer_id]
 
-    # 2) агрегат лайков по твиту
+    # 2) агрегат лайков
     likes_agg = (
         select(Like.tweet_id, func.count(Like.id).label("likes_cnt"))
         .group_by(Like.tweet_id)
         .subquery()
     )
 
-    # 3) выборка твитов + сортировка: популярность ↓, затем дата ↓
+    # 3) выборка твитов + сортировка
     q = (
         select(Tweet, func.coalesce(likes_agg.c.likes_cnt, 0).label("likes_cnt"))
         .where(Tweet.author_id.in_(author_ids))
@@ -140,17 +172,12 @@ async def list_feed_for_user(session, *, viewer_id: int) -> list[TweetOut]:
 
     rows = (await session.execute(q)).all()
     tweets = [row[0] for row in rows]
+    if not tweets:
+        return []
 
-    # 4) добираем список лайкнувших (просто; оптимизации — позже)
-    dtos: list[TweetOut] = []
+    # 4) лайкнувшие + DTO
+    dtos: List[TweetOut] = []
     for t in tweets:
-        likers_q = (
-            select(User)
-            .join(Like, Like.user_id == User.id)
-            .where(Like.tweet_id == t.id)
-            .order_by(User.username.asc())
-        )
-        likers = (await session.execute(likers_q)).scalars().all()
+        likers = await _fetch_likers(session, t.id)
         dtos.append(_tweet_to_dto(t, likers=likers))
-
     return dtos

--- a/app/tests/test_follows.py
+++ b/app/tests/test_follows.py
@@ -1,77 +1,192 @@
 # app/tests/test_follows.py
 import pytest
 
-FOLLOW_POST_PATH = "/api/users/{user_id}/follow"
+FOLLOW_POST = "/api/users/{user_id}/follow"
+FOLLOW_DEL = "/api/users/{user_id}/follow"
+PROFILE_GET = "/api/users/{user_id}"
 
 
 @pytest.mark.asyncio
 async def test_follow_user(client, seed_users):
+    """Первый follow — 200 OK, повторный — конфликт (409/400)."""
     headers = {"api-key": seed_users["alice"]["api_key"]}
     bob_id = seed_users["bob"]["id"]
 
     # первый follow
-    response_follow = await client.post(f"/api/users/{bob_id}/follow", headers=headers)
-    assert response_follow.status_code == 200
-    assert response_follow.json()["result"] is True
+    r1 = await client.post(FOLLOW_POST.format(user_id=bob_id), headers=headers)
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["result"] is True
 
     # повторный follow → AlreadyExists
-    response_duplicate = await client.post(f"/api/users/{bob_id}/follow", headers=headers)
-    assert response_duplicate.status_code in (400, 409)
+    r2 = await client.post(FOLLOW_POST.format(user_id=bob_id), headers=headers)
+    assert r2.status_code in (400, 409), r2.text
 
 
 @pytest.mark.asyncio
 async def test_unfollow_user(client, seed_users):
+    """unfollow работает и идемпотентен: второй вызов тоже 200 OK."""
     headers = {"api-key": seed_users["alice"]["api_key"]}
     bob_id = seed_users["bob"]["id"]
 
-    # подписываемся, чтобы было что удалять
-    await client.post(f"/api/users/{bob_id}/follow", headers=headers)
+    # подготовка: подписались
+    _ = await client.post(FOLLOW_POST.format(user_id=bob_id), headers=headers)
 
     # первый unfollow
-    response_unfollow = await client.delete(f"/api/users/{bob_id}/follow", headers=headers)
-    assert response_unfollow.status_code == 200
-    assert response_unfollow.json()["result"] is True
+    r1 = await client.delete(FOLLOW_DEL.format(user_id=bob_id), headers=headers)
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["result"] is True
 
-    # проверка идемпотентно: тоже ок
-    response_repeat_unfollow = await client.delete(f"/api/users/{bob_id}/follow", headers=headers)
-    assert response_repeat_unfollow.status_code == 200
+    # повторный unfollow — тоже ок
+    r2 = await client.delete(FOLLOW_DEL.format(user_id=bob_id), headers=headers)
+    assert r2.status_code == 200, r2.text
 
-    @pytest.mark.asyncio
-    async def test_feed_contains_followee_tweets_and_sort(client, seed_users):
-        # Alice будет смотреть ленту, Bob — автор
-        alice = seed_users["alice"]
-        bob = seed_users["bob"]
-        h_alice = {"api-key": alice["api_key"]}
-        h_bob = {"api-key": bob["api_key"]}
 
-        # Bob публикует два твита
-        t1 = await client.post(
-            "/api/tweets", headers=h_bob, json={"tweet_data": "B-1", "tweet_media_ids": []}
-        )
-        t2 = await client.post(
-            "/api/tweets", headers=h_bob, json={"tweet_data": "B-2", "tweet_media_ids": []}
-        )
-        assert t1.status_code in (200, 201) and t2.status_code in (200, 201)
-        id1, id2 = t1.json()["tweet_id"], t2.json()["tweet_id"]
+@pytest.mark.asyncio
+async def test_feed_contains_followee_tweets_and_sort(client, seed_users):
+    """
+    Лента содержит твиты подписок и сортируется по лайкам ↓ затем по дате ↓.
 
-        # Alice подписывается на Bob (если требуется)
-        rfollow = await client.post(FOLLOW_POST_PATH.format(user_id=bob["id"]), headers=h_alice)
-        assert rfollow.status_code in (200, 201, 409), rfollow.text
+    Сценарий:
+      - Bob постит B-1, B-2
+      - Alice подписывается на Bob
+      - Alice лайкает B-2
+      - В ленте Alice: B-2 раньше B-1
+    """
+    alice = seed_users["alice"]
+    bob = seed_users["bob"]
+    h_alice = {"api-key": alice["api_key"]}
+    h_bob = {"api-key": bob["api_key"]}
 
-        # Лайкнем второй твит, чтобы проверить сортировку по популярности
-        _ = await client.post(f"/api/tweets/{id2}/likes", headers=h_alice)
+    # Bob публикует два твита
+    t1 = await client.post(
+        "/api/tweets",
+        headers=h_bob,
+        json={"tweet_data": "B-1", "tweet_media_ids": []},
+    )
+    t2 = await client.post(
+        "/api/tweets",
+        headers=h_bob,
+        json={"tweet_data": "B-2", "tweet_media_ids": []},
+    )
+    assert t1.status_code in (200, 201) and t2.status_code in (200, 201)
+    id1, id2 = t1.json()["tweet_id"], t2.json()["tweet_id"]
 
-        # Лента Alice
-        rf = await client.get("/api/tweets", headers=h_alice)
-        assert rf.status_code == 200, rf.text
-        feed = rf.json()["tweets"]
+    # Alice подписывается на Bob (допускаем 409, если уже была подписка)
+    rfollow = await client.post(FOLLOW_POST.format(user_id=bob["id"]), headers=h_alice)
+    assert rfollow.status_code in (200, 201, 409), rfollow.text
 
-        # Оба твита Bob должны быть в ленте
-        feed_ids = [t["id"] for t in feed]
-        assert id1 in feed_ids and id2 in feed_ids
+    # Лайкнем второй твит, чтобы проверить сортировку по популярности
+    _ = await client.post(f"/api/tweets/{id2}/likes", headers=h_alice)
 
-        # Если у вас сортировка: по лайкам ↓, затем по дате ↓,
-        # то более залайканный твит (id2) должен идти раньше id1.
-        # Проверим относительный порядок:
-        pos = {t["id"]: i for i, t in enumerate(feed)}
-        assert pos[id2] < pos[id1]
+    # Лента Alice
+    rf = await client.get("/api/tweets", headers=h_alice)
+    assert rf.status_code == 200, rf.text
+    feed = rf.json()["tweets"]
+
+    # Оба твита Bob должны быть в ленте
+    feed_ids = [t["id"] for t in feed]
+    assert id1 in feed_ids and id2 in feed_ids
+
+    # Более залайканный твит (id2) должен идти раньше id1
+    pos = {t["id"]: i for i, t in enumerate(feed)}
+    assert pos[id2] < pos[id1]
+
+
+@pytest.mark.asyncio
+async def test_follow_nonexistent_user_returns_not_found(client, seed_users):
+    """Подписка на несуществующего пользователя → EntityNotFound (404/400)."""
+    alice = seed_users["alice"]
+    h_alice = {"api-key": alice["api_key"]}
+
+    nonexistent_id = 999_999
+    r = await client.post(FOLLOW_POST.format(user_id=nonexistent_id), headers=h_alice)
+    assert r.status_code in (400, 404), r.text
+    body = r.json()
+    assert body["result"] is False
+    assert body["error_type"] in ("EntityNotFound", "DomainValidation")
+
+
+@pytest.mark.asyncio
+async def test_follow_self_forbidden(client, seed_users):
+    """Нельзя подписаться на себя → ForbiddenAction (403/400)."""
+    bob = seed_users["bob"]
+    h_bob = {"api-key": bob["api_key"]}
+
+    r = await client.post(FOLLOW_POST.format(user_id=bob["id"]), headers=h_bob)
+    assert r.status_code in (400, 403), r.text
+    body = r.json()
+    assert body["result"] is False
+    assert body["error_type"] in ("ForbiddenAction", "DomainValidation")
+
+
+@pytest.mark.asyncio
+async def test_follow_duplicate_returns_conflict(client, seed_users):
+    """Повторная подписка → AlreadyExists (обычно 409)."""
+    alice = seed_users["alice"]
+    jack = seed_users["jack"]
+    h_alice = {"api-key": alice["api_key"]}
+
+    r1 = await client.post(FOLLOW_POST.format(user_id=jack["id"]), headers=h_alice)
+    assert r1.status_code in (200, 201), r1.text
+
+    r2 = await client.post(FOLLOW_POST.format(user_id=jack["id"]), headers=h_alice)
+    assert r2.status_code in (400, 409), r2.text
+    body = r2.json()
+    assert body["result"] is False
+    assert body["error_type"] in ("AlreadyExists", "DomainValidation")
+
+
+@pytest.mark.asyncio
+async def test_unfollow_is_idempotent_even_if_never_followed(client, seed_users):
+    """Отписка без существующей подписки → 200 (идемпотентно)."""
+    alice = seed_users["alice"]
+    jack = seed_users["jack"]
+    h_alice = {"api-key": alice["api_key"]}
+
+    r = await client.delete(FOLLOW_DEL.format(user_id=jack["id"]), headers=h_alice)
+    assert r.status_code == 200, r.text
+    assert r.json()["result"] is True
+
+
+@pytest.mark.asyncio
+async def test_profile_nonexistent_user_returns_not_found(client, seed_users):
+    """Профиль несуществующего пользователя → EntityNotFound (404/400)."""
+    alice = seed_users["alice"]
+    h_alice = {"api-key": alice["api_key"]}
+
+    nonexistent_id = 888_888
+    r = await client.get(PROFILE_GET.format(user_id=nonexistent_id), headers=h_alice)
+    assert r.status_code in (400, 404), r.text
+    body = r.json()
+    assert body["result"] is False
+    assert body["error_type"] in ("EntityNotFound", "DomainValidation")
+
+
+@pytest.mark.asyncio
+async def test_profile_lists_followers_and_following_consistently(client, seed_users):
+    """Профиль содержит корректные followers/following (id+имя)."""
+    alice = seed_users["alice"]
+    bob = seed_users["bob"]
+    jack = seed_users["jack"]
+
+    h_alice = {"api-key": alice["api_key"]}
+    h_bob = {"api-key": bob["api_key"]}
+
+    # Alice → follow Bob, Jack
+    await client.post(FOLLOW_POST.format(user_id=bob["id"]), headers=h_alice)
+    await client.post(FOLLOW_POST.format(user_id=jack["id"]), headers=h_alice)
+
+    # Bob → follow Alice
+    await client.post(FOLLOW_POST.format(user_id=alice["id"]), headers=h_bob)
+
+    rp = await client.get(PROFILE_GET.format(user_id=alice["id"]), headers=h_alice)
+    assert rp.status_code == 200, rp.text
+    profile = rp.json()["user"]
+
+    # following у Alice: bob, jack
+    following_names = sorted([u.get("name") for u in profile["following"]])
+    assert following_names == sorted(["bob", "jack"])
+
+    # followers у Alice: bob
+    follower_names = sorted([u.get("name") for u in profile["followers"]])
+    assert "bob" in follower_names

--- a/app/tests/test_likes.py
+++ b/app/tests/test_likes.py
@@ -1,59 +1,112 @@
 # app/tests/test_likes.py
 import pytest
 
+TWEETS_PATH = "/api/tweets"
 
-async def _create_tweet(client, *, author_api_key: str, text: str) -> int:
+
+async def _create_tweet(client, *, api_key: str, text: str) -> int:
     """Хелпер: создаёт твит и возвращает его id."""
-    headers = {"api-key": author_api_key}
+    headers = {"api-key": api_key}
     payload = {"tweet_data": text, "tweet_media_ids": None}
-    resp = await client.post("/api/tweets", headers=headers, json=payload)
-    assert resp.status_code == 200, resp.text
+    resp = await client.post(TWEETS_PATH, headers=headers, json=payload)
+    assert resp.status_code in (200, 201), resp.text
     return resp.json()["tweet_id"]
 
 
 @pytest.mark.asyncio
-async def test_like_then_duplicate_returns_error(client, seed_users):
-    """Поставить лайк и проверить, что повторный лайк даёт 400/409."""
-    alice_api_key = seed_users["alice"]["api_key"]  # автор твита
-    bob_api_key = seed_users["bob"]["api_key"]  # ставит лайк
+async def test_like_then_duplicate_returns_conflict(client, seed_users):
+    """Первый лайк — OK, повторный — конфликт (400/409)."""
+    alice = seed_users["alice"]["api_key"]  # автор твита
+    bob = seed_users["bob"]["api_key"]  # ставит лайк
 
-    tweet_id = await _create_tweet(client, author_api_key=alice_api_key, text="like me")
+    tweet_id = await _create_tweet(client, api_key=alice, text="like me")
 
     # первый лайк — ок
-    like_resp = await client.post(f"/api/tweets/{tweet_id}/likes", headers={"api-key": bob_api_key})
-    assert like_resp.status_code == 200
-    assert like_resp.json()["result"] is True
+    r1 = await client.post(f"{TWEETS_PATH}/{tweet_id}/likes", headers={"api-key": bob})
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["result"] is True
 
-    # повторный лайк — конфликт (наш хендлер может вернуть 400 или 409)
-    duplicate_like_resp = await client.post(
-        f"/api/tweets/{tweet_id}/likes", headers={"api-key": bob_api_key}
-    )
-    assert duplicate_like_resp.status_code in (400, 409), duplicate_like_resp.text
+    # повторный лайк — конфликт
+    r2 = await client.post(f"{TWEETS_PATH}/{tweet_id}/likes", headers={"api-key": bob})
+    assert r2.status_code in (400, 409), r2.text
 
 
 @pytest.mark.asyncio
 async def test_unlike_is_idempotent(client, seed_users):
     """Снятие лайка дважды подряд возвращает 200 оба раза (идемпотентно)."""
-    alice_api_key = seed_users["alice"]["api_key"]
-    bob_api_key = seed_users["bob"]["api_key"]
+    alice = seed_users["alice"]["api_key"]
+    bob = seed_users["bob"]["api_key"]
 
-    tweet_id = await _create_tweet(client, author_api_key=alice_api_key, text="unlike me")
+    tweet_id = await _create_tweet(client, api_key=alice, text="unlike me")
 
     # предварительно поставим лайк
-    first_like = await client.post(
-        f"/api/tweets/{tweet_id}/likes", headers={"api-key": bob_api_key}
-    )
-    assert first_like.status_code == 200
+    like = await client.post(f"{TWEETS_PATH}/{tweet_id}/likes", headers={"api-key": bob})
+    assert like.status_code == 200, like.text
 
     # первый анлайк — ок
-    first_unlike = await client.delete(
-        f"/api/tweets/{tweet_id}/likes", headers={"api-key": bob_api_key}
-    )
-    assert first_unlike.status_code == 200
-    assert first_unlike.json()["result"] is True
+    r1 = await client.delete(f"{TWEETS_PATH}/{tweet_id}/likes", headers={"api-key": bob})
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["result"] is True
 
     # второй анлайк — тоже ок (идемпотентно)
-    second_unlike = await client.delete(
-        f"/api/tweets/{tweet_id}/likes", headers={"api-key": bob_api_key}
-    )
-    assert second_unlike.status_code == 200
+    r2 = await client.delete(f"{TWEETS_PATH}/{tweet_id}/likes", headers={"api-key": bob})
+    assert r2.status_code == 200, r2.text
+
+
+@pytest.mark.asyncio
+async def test_unlike_without_like_is_ok(client, seed_users):
+    """Снятие лайка без предварительного лайка → 200 (идемпотентно)."""
+    alice = seed_users["alice"]["api_key"]
+    bob = seed_users["bob"]["api_key"]
+
+    tweet_id = await _create_tweet(client, api_key=alice, text="no like yet")
+
+    r = await client.delete(f"{TWEETS_PATH}/{tweet_id}/likes", headers={"api-key": bob})
+    assert r.status_code == 200, r.text
+    assert r.json()["result"] is True
+
+
+@pytest.mark.asyncio
+async def test_like_nonexistent_tweet_returns_not_found(client, seed_users):
+    """Лайк несуществующего твита → 404/400 (EntityNotFound/DomainValidation)."""
+    bob = seed_users["bob"]["api_key"]
+    nonexistent_id = 999_999
+
+    r = await client.post(f"{TWEETS_PATH}/{nonexistent_id}/likes", headers={"api-key": bob})
+    assert r.status_code in (400, 404), r.text
+    body = r.json()
+    assert body["result"] is False
+    assert body["error_type"] in ("EntityNotFound", "DomainValidation")
+
+
+@pytest.mark.asyncio
+async def test_likes_reflected_in_feed(client, seed_users):
+    """После лайка твит содержит в likes пользователя, который лайкнул."""
+    alice_key = seed_users["alice"]["api_key"]  # автор
+    bob_key = seed_users["bob"]["api_key"]  # лайкает
+    bob_id = seed_users["bob"]["id"]
+    alice_id = seed_users["alice"]["id"]
+
+    tweet_id = await _create_tweet(client, api_key=alice_key, text="check likes")
+
+    # Bob подписывается на Alice, чтобы видеть её твиты в своей ленте
+    r_follow = await client.post(f"/api/users/{alice_id}/follow", headers={"api-key": bob_key})
+    assert r_follow.status_code in (200, 201, 409), r_follow.text  # 409 допустим, если уже подписан
+
+    # лайк от Bob
+    r_like = await client.post(f"{TWEETS_PATH}/{tweet_id}/likes", headers={"api-key": bob_key})
+    assert r_like.status_code == 200, r_like.text
+
+    # запрос ленты Bob — теперь твит Alice должен быть виден
+    feed = await client.get(TWEETS_PATH, headers={"api-key": bob_key})
+    assert feed.status_code == 200, feed.text
+
+    tws = feed.json()["tweets"]
+    target = next(t for t in tws if t["id"] == tweet_id)
+
+    liker_names = [u["name"] for u in target["likes"]]
+    liker_ids = [u["user_id"] for u in target["likes"]]
+
+    # в лайкерах есть Bob
+    assert bob_id in liker_ids
+    assert "bob" in liker_names

--- a/app/tests/test_medias.py
+++ b/app/tests/test_medias.py
@@ -6,33 +6,56 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_upload_media_png(client, seed_users):
+    """Успешная загрузка одного PNG, в ответе media_id (int)."""
     headers = {"api-key": seed_users["alice"]["api_key"]}
     png_bytes = b"\x89PNG\r\n\x1a\n" + b"fake"  # минимальный фейк
-    files = [("files", ("test.png", io.BytesIO(png_bytes), "image/png"))]
+
+    # одиночная загрузка: поле строго "file"
+    files = {"file": ("test.png", io.BytesIO(png_bytes), "image/png")}
     r = await client.post("/api/medias", headers=headers, files=files)
+
     assert r.status_code in (200, 201), r.text
     data = r.json()
     assert data["result"] is True
-    assert isinstance(data["media_ids"][0], int)
+    assert isinstance(data["media_id"], int)
 
 
 @pytest.mark.asyncio
-async def test_upload_media_multi(client, seed_users):
+async def test_create_tweet_with_uploaded_media(client, seed_users):
+    """Загружаем медиа → создаём твит с этим медиа → в ленте есть вложение .png."""
     headers = {"api-key": seed_users["alice"]["api_key"]}
 
-    jpg_bytes = b"\xff\xd8\xff" + b"fakejpeg"
-    png_bytes = b"\x89PNG\r\n\x1a\n" + b"fakepng"
+    files = {"file": ("a.png", io.BytesIO(b"\x89PNG\r\n\x1a\nfake"), "image/png")}
+    rm = await client.post("/api/medias", headers=headers, files=files)
+    assert rm.status_code in (200, 201), rm.text
+    media_id = rm.json()["media_id"]
 
-    # multipart с несколькими файлами: список пар ("files", (<filename>, <fileobj>, <ctype>))
-    files = [
-        ("files", ("a.jpg", io.BytesIO(jpg_bytes), "image/jpeg")),
-        ("files", ("b.png", io.BytesIO(png_bytes), "image/png")),
-    ]
+    payload = {"tweet_data": "тестовый твит", "tweet_media_ids": [media_id]}
+    rt = await client.post("/api/tweets", headers=headers, json=payload)
+    assert rt.status_code in (200, 201), rt.text
+    tid = rt.json()["tweet_id"]
 
+    rf = await client.get("/api/tweets", headers=headers)
+    assert rf.status_code == 200, rf.text
+    tweets = rf.json()["tweets"]
+    t = next(t for t in tweets if t["id"] == tid)
+    assert t["attachments"], "Ожидали хотя бы одно вложение"
+    assert all(isinstance(p, str) for p in t["attachments"])
+    # путь относительный и ведёт в media/
+    assert any(a.startswith("media/") and a.endswith(".png") for a in t["attachments"])
+
+
+@pytest.mark.asyncio
+async def test_upload_media_invalid_type_returns_400(client, seed_users):
+    """Попытка загрузить text/plain → 400 DomainValidation с сообщением о типе."""
+    headers = {"api-key": seed_users["alice"]["api_key"]}
+    bad_bytes = b"not-really-a-media-file"
+
+    files = {"file": ("bad.txt", io.BytesIO(bad_bytes), "text/plain")}
     r = await client.post("/api/medias", headers=headers, files=files)
-    assert r.status_code in (200, 201), r.text
+
+    assert r.status_code == 400, r.text
     data = r.json()
-    assert data["result"] is True
-    assert isinstance(data.get("media_ids"), list)
-    assert len(data["media_ids"]) == 2
-    assert all(isinstance(x, int) for x in data["media_ids"])
+    assert data["result"] is False
+    assert data["error_type"] == "DomainValidation"
+    assert "unsupported media type" in data["error_message"]

--- a/app/tests/test_tweets.py
+++ b/app/tests/test_tweets.py
@@ -1,61 +1,212 @@
+# app/tests/test_tweets.py
+"""
+Тесты /api/tweets:
+- создание без/с медиа
+- валидации (пусто → 400; >280 → 422 от Pydantic; несуществующий media → 404)
+- удаление: своё (ок), чужое → 403, несуществующее → 404
+- сортировка ленты: likes ↓, затем created_at ↓
+- attachments: относительные пути "media/<...>"
+"""
+
 import io
 
 import pytest
 
+TWEETS_PATH = "/api/tweets"
+MEDIAS_PATH = "/api/medias"
+
+
+# --------- helpers ---------
+
+
+async def _upload_png(client, headers, name="a.png"):
+    png = b"\x89PNG\r\n\x1a\nfake"
+    files = {"file": (name, io.BytesIO(png), "image/png")}
+    r = await client.post(MEDIAS_PATH, headers=headers, files=files)
+    assert r.status_code in (200, 201), r.text
+    return r.json()["media_id"]
+
+
+async def _create_tweet(client, headers, text, media_ids=None):
+    payload = {"tweet_data": text, "tweet_media_ids": media_ids or []}
+    return await client.post(TWEETS_PATH, headers=headers, json=payload)
+
+
+# --------- базовые сценарии ---------
+
 
 @pytest.mark.asyncio
 async def test_create_tweet_without_media_and_list(client, seed_users):
-    headers = {"api-key": seed_users["bob"]["api_key"]}
+    """Создание твита без медиа и проверка появления в ленте автора."""
+    h = {"api-key": seed_users["bob"]["api_key"]}
 
-    # создаём твит без медиа
-    payload = {"tweet_data": "hello world", "tweet_media_ids": None}
-    r = await client.post("/api/tweets", json=payload, headers=headers)
-    assert r.status_code == 200
-    tweet_id = r.json()["tweet_id"]
-    assert isinstance(tweet_id, int)
+    r = await _create_tweet(client, h, text="hello world")
+    assert r.status_code == 200, r.text
+    tid = r.json()["tweet_id"]
+    assert isinstance(tid, int)
 
-    # получаем ленту боба — в ней должен быть его твит
-    r2 = await client.get("/api/tweets", headers=headers)
-    assert r2.status_code == 200
+    r2 = await client.get(TWEETS_PATH, headers=h)
+    assert r2.status_code == 200, r2.text
     items = r2.json()["tweets"]
-    assert any(t["id"] == tweet_id for t in items)
+    assert any(t["id"] == tid for t in items)
 
 
 @pytest.mark.asyncio
 async def test_create_tweet_with_media(client, seed_users):
-    headers = {"api-key": seed_users["alice"]["api_key"]}
+    """Создание твита с предварительно загруженным PNG."""
+    h = {"api-key": seed_users["alice"]["api_key"]}
 
-    # загружаем медиа
-    png = b"\x89PNG\r\n\x1a\nfake"
-    files = {"files": ("a.png", io.BytesIO(png), "image/png")}
-    rm = await client.post("api/medias", headers=headers, files=files)
-    mid = rm.json()["media_ids"][0]
+    mid = await _upload_png(client, h, name="pic.png")
 
-    # создаём твит с этим медиа
-    payload = {"tweet_data": "тестовый твит", "tweet_media_ids": [mid]}
-    rt = await client.post("api/tweets", headers=headers, json=payload)
+    rt = await _create_tweet(client, h, text="тестовый твит", media_ids=[mid])
+    assert rt.status_code == 200, rt.text
     tid = rt.json()["tweet_id"]
 
-    # проверяем, что он в ленте
-    rf = await client.get("api/tweets", headers=headers)
+    rf = await client.get(TWEETS_PATH, headers=h)
+    assert rf.status_code == 200, rf.text
     tweets = rf.json()["tweets"]
     assert any(t["id"] == tid for t in tweets)
 
 
 @pytest.mark.asyncio
-async def test_delete_tweet(client, seed_users):
-    headers = {"api-key": seed_users["alice"]["api_key"]}
+async def test_delete_own_tweet(client, seed_users):
+    """Создание и удаление своего твита — из ленты пропадает."""
+    h = {"api-key": seed_users["alice"]["api_key"]}
 
-    # создаём твит без медиа (чтобы было что удалять)
-    payload = {"tweet_data": "тест на удаление", "tweet_media_ids": []}
-    rt = await client.post("api/tweets", headers=headers, json=payload)
+    rt = await _create_tweet(client, h, text="тест на удаление")
+    assert rt.status_code == 200, rt.text
     tid = rt.json()["tweet_id"]
 
-    # удаляем его
-    rd = await client.delete(f"api/tweets/{tid}", headers=headers)
+    rd = await client.delete(f"{TWEETS_PATH}/{tid}", headers=h)
+    assert rd.status_code == 200, rd.text
     assert rd.json()["result"] is True
 
-    # убеждаемся, что в ленте его больше нет
-    rf = await client.get("api/tweets", headers=headers)
+    rf = await client.get(TWEETS_PATH, headers=h)
+    assert rf.status_code == 200, rf.text
     tweets = rf.json()["tweets"]
     assert not any(t["id"] == tid for t in tweets)
+
+
+# --------- валидации ---------
+
+
+@pytest.mark.asyncio
+async def test_create_tweet_validation_empty(client, seed_users):
+    """Пустой контент → 400 DomainValidation (валидация сервиса)."""
+    h = {"api-key": seed_users["alice"]["api_key"]}
+    r = await _create_tweet(client, h, text="  ")
+    assert r.status_code == 400, r.text
+    body = r.json()
+    assert body["result"] is False
+    assert body["error_type"] == "DomainValidation"
+
+
+@pytest.mark.asyncio
+async def test_create_tweet_validation_too_long(client, seed_users):
+    """Контент >280 символов → 422 от Pydantic-схемы TweetCreate."""
+    h = {"api-key": seed_users["alice"]["api_key"]}
+    long_text = "x" * 281
+    r = await _create_tweet(client, h, text=long_text)
+    assert r.status_code == 422, r.text
+    detail = r.json().get("detail", [])
+    assert any(
+        e.get("type") == "string_too_long" and e.get("loc") == ["body", "tweet_data"]
+        for e in detail
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_tweet_with_nonexistent_media_returns_not_found(client, seed_users):
+    """Несуществующий media_id → 404 EntityNotFound."""
+    h = {"api-key": seed_users["alice"]["api_key"]}
+    r = await _create_tweet(client, h, text="hello", media_ids=[999_999])
+    assert r.status_code == 404, r.text
+    body = r.json()
+    assert body["result"] is False
+    assert body["error_type"] == "EntityNotFound"
+
+
+# --------- удаление: ошибки ---------
+
+
+@pytest.mark.asyncio
+async def test_delete_foreign_tweet_forbidden(client, seed_users):
+    """Удаление чужого твита → 403 ForbiddenAction."""
+    alice = seed_users["alice"]
+    bob = seed_users["bob"]
+
+    h_alice = {"api-key": alice["api_key"]}
+    h_bob = {"api-key": bob["api_key"]}
+
+    rb = await _create_tweet(client, h_bob, text="bob tweet")
+    assert rb.status_code == 200, rb.text
+    tid = rb.json()["tweet_id"]
+
+    rd = await client.delete(f"{TWEETS_PATH}/{tid}", headers=h_alice)
+    assert rd.status_code == 403, rd.text
+    body = rd.json()
+    assert body["result"] is False
+    assert body["error_type"] == "ForbiddenAction"
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_tweet_not_found(client, seed_users):
+    """Удаление несуществующего твита → 404 EntityNotFound."""
+    h = {"api-key": seed_users["alice"]["api_key"]}
+    rd = await client.delete(f"{TWEETS_PATH}/987654321", headers=h)
+    assert rd.status_code == 404, rd.text
+    body = rd.json()
+    assert body["result"] is False
+    assert body["error_type"] == "EntityNotFound"
+
+
+# --------- сортировка ленты ---------
+
+
+@pytest.mark.asyncio
+async def test_feed_sort_by_likes_then_date(client, seed_users):
+    """
+    Лента сортируется по лайкам ↓, затем по дате ↓:
+      - Bob постит B1, B2
+      - Alice фолловит Bob
+      - Alice лайкает B2
+      - В ленте Alice: B2 раньше B1
+    """
+    alice = seed_users["alice"]
+    bob = seed_users["bob"]
+
+    h_alice = {"api-key": alice["api_key"]}
+    h_bob = {"api-key": bob["api_key"]}
+
+    r1 = await _create_tweet(client, h_bob, text="B1")
+    r2 = await _create_tweet(client, h_bob, text="B2")
+    assert r1.status_code == 200 and r2.status_code == 200
+    id1, id2 = r1.json()["tweet_id"], r2.json()["tweet_id"]
+
+    rf = await client.post(f"/api/users/{bob['id']}/follow", headers=h_alice)
+    assert rf.status_code in (200, 201, 409), rf.text
+
+    _ = await client.post(f"/api/tweets/{id2}/likes", headers=h_alice)
+
+    feed = (await client.get(TWEETS_PATH, headers=h_alice)).json()["tweets"]
+    pos = {t["id"]: i for i, t in enumerate(feed)}
+    assert pos[id2] < pos[id1]
+
+
+# --------- attachments ---------
+
+
+@pytest.mark.asyncio
+async def test_attachments_paths_echo_back(client, seed_users):
+    """PNG попадает в attachments как относительный путь 'media/<file>'."""
+    h = {"api-key": seed_users["alice"]["api_key"]}
+    mid = await _upload_png(client, h, name="pic.png")
+
+    r = await _create_tweet(client, h, text="with image", media_ids=[mid])
+    assert r.status_code == 200, r.text
+    tid = r.json()["tweet_id"]
+
+    feed = (await client.get(TWEETS_PATH, headers=h)).json()["tweets"]
+    tw = next(t for t in feed if t["id"] == tid)
+    assert tw["attachments"], "attachments must not be empty"
+    assert any(p.endswith(".png") and p.startswith("media/") for p in tw["attachments"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [tool.ruff]
-# Поддержка PEP8 + isort + часть flake8
 line-length = 100
 target-version = "py312"
 exclude = [
@@ -10,10 +9,12 @@ exclude = [
   "build",
   "app/media",
 ]
-# Правила: базовые + isort + pyflakes и пр.
-select = ["E", "F", "W", "I"]
-# миграции обычно трогаем реже — можно смягчить
 extend-exclude = ["migrations"]
+
+[tool.ruff.lint]
+# базовые правила: pycodestyle (E, W), pyflakes (F), isort (I)
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]
 
 [tool.black]
 line-length = 100
@@ -21,10 +22,10 @@ target-version = ["py312"]
 exclude = '''
 /(
   \.venv
- |\.git
- |__pycache__
- |dist
- |build
+  | \.git
+  | __pycache__
+  | dist
+  | build
 )/
 '''
 


### PR DESCRIPTION
Подключён frontend SPA (папка dist) через FastAPI StaticFiles
Переписан и выровнен бэкенд API строго под ТЗ:
users (me, get by id, follow/unfollow, profile)
tweets (create, list, feed, delete)
likes (like/unlike)
medias (upload, валидация формата)
Добавлен полный набор тестов:
test_users.py — авторизация, профили, follow/unfollow
test_follows.py — связи и лента по подпискам
test_tweets.py — CRUD твитов, сортировка, валидация
test_likes.py — like/unlike, отражение в ленте
test_medias.py — загрузка и привязка медиа, ошибки формата
Все тесты проходят
Линтеры и типизация настроены:
ruff, black, mypy
конфигурация в pyproject.toml
Докеризация: можно запускать docker-compose up, фронт и бэк собираются вместе